### PR TITLE
Fix missing dependency in gemspec. Add :server option in Client class

### DIFF
--- a/facepp.gemspec
+++ b/facepp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'facepp'
-  s.version = '0.0'
+  s.version = '0.2'
   s.platform = Gem::Platform::RUBY
   s.summary = 'A Ruby interface to the FacePlusPlus API.'
   s.description = 'FacePlusPlus API Reference: http://faceplusplus.com/en/docs/getting_started'
@@ -13,5 +13,6 @@ Gem::Specification.new do |s|
   s.files += Dir.glob 'spec/**/*'
   s.require_paths = ['lib']
 
+  s.add_dependency 'mime-types'
   s.add_development_dependency 'rspec'
 end

--- a/lib/facepp/client.rb
+++ b/lib/facepp/client.rb
@@ -156,7 +156,8 @@ class FacePP
           req.body = form.inspect
           req['Content-Length'] = req.body.size
         end
-        res = Net::HTTP.new('api.faceplusplus.com').request(req).body
+        server = options.fetch :server, 'api.faceplusplus.com'
+        res = Net::HTTP.new(server).request(req).body
         decode ? JSON.load(res) : res
       end
     end


### PR DESCRIPTION
This PR fix issues I had during installation process.
It also adds a new option (:server) to the client init so it's possible specify what is the endpoint (US or CH).
